### PR TITLE
Fix requirements issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,6 @@ install:
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
-  - "python -m pip install -r requirements.txt"
   - "python -m pip install -r requirements-test.txt"
 
 build: off

--- a/pymem/process.py
+++ b/pymem/process.py
@@ -3,12 +3,6 @@ import ctypes.wintypes
 import platform
 import copy
 
-from win32api import GetCurrentProcess
-from win32security import GetSecurityInfo
-from win32security import SetSecurityInfo
-import win32security
-import win32api
-
 import pymem.ressources.kernel32
 import pymem.ressources.psapi
 import pymem.ressources.structure

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-pypiwin32

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,15 @@
+import pathlib
 import setuptools
+
+ROOT = pathlib.Path(__file__).parent
+
+extras = {}
+
+with open(ROOT / 'requirements-doc.txt', encoding='utf-8') as fp:
+    extras['doc'] = fp.read().splitlines()
+
+with open(ROOT / 'requirements-test.txt', encoding='utf-8') as fp:
+    extras['test'] = fp.read().splitlines()
 
 
 setuptools.setup(
@@ -22,7 +33,5 @@ setuptools.setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
     ],
-    install_requires=[
-        'sphinx_rtd_theme'
-    ],
+    extras_require=extras,
 )


### PR DESCRIPTION
This pull request removes sphinx from the required installs and moves it to the [doc] extra option.
It also adds the tests requirements to the [test] extra option.
I removed requirements.txt because pypiwin32 was not actually used anywhere in the code besides process.py where it was only imported and not used within the file (those imports where also removed).

This pull request also closes issue #20  