### PR TITLE
disabling debug mode now works properly

### DIFF
--- a/pymem/process.py
+++ b/pymem/process.py
@@ -131,7 +131,7 @@ def open(process_id, debug=None, process_access=None):
     :return: A handle of the given process_id
     :rtype: ctypes.c_void_p
     """
-    if not debug:
+    if debug is None:
         debug = True
     if not process_access:
         process_access = pymem.ressources.structure.PROCESS.PROCESS_ALL_ACCESS.value


### PR DESCRIPTION
Previously if you had the parameter `debug=False` it would always be made `True` because of the incorrect condition