### PR TITLE
Fix 30/32

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
 
   matrix:
     # For Python versions available on Appveyor, see
-    # http://www.appveyor.com/docs/installed-software#python
+    # https://www.appveyor.com/docs/windows-images-software/#python
     # The list here is complete (excluding Python 2.6, which
     # isn't covered by this document) at the time of writing.
 
@@ -13,6 +13,10 @@ environment:
     - PYTHON: "C:\\Python35-x64"
       PYTHON_ARCH: "64"
     - PYTHON: "C:\\Python36-x64"
+      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python38-x64"
       PYTHON_ARCH: "64"
 
 matrix:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -9,6 +9,29 @@ If you are familiar with pyenv_, it is highly recommended to sandbox pymem insta
 
 .. _pyenv: https://github.com/pyenv/pyenv
 
+Path
+----
+
+In order to use all pymem fonctionalities you have to first make sure that system python directory is configured within
+windows system PATH.
+
+In a PowerShell window type:
+
+.. code-block:: sh
+
+    $env:PATH
+
+This PATH should contain the directory where python is installed system wide or at least have access to pythonXX.dll
+If you don't find python in your PATH, then it is recommended to add it.
+
+.. code-block:: sh
+
+    - Open the Start Search, type in "env", and choose "Edit the system environment variables"
+    - Click the "Environment Variables..." button
+    - Under the "System Variables" section (the lower half), find the row with "Path" in the first column, and click edit.
+    - The "Edit environment variable" UI will appear. Here, you can click "New" and type in the new path you want to add.
+    - Add your python path and close the windows (something like: C:\Users\xxx\AppData\Local\Programs\Python\Python38)
+
 Virtual environments
 --------------------
 

--- a/pymem/__init__.py
+++ b/pymem/__init__.py
@@ -159,6 +159,7 @@ class Pymem(object):
             The new thread identifier
         """
         thread_id = ctypes.c_ulong(0)
+        ctypes.windll.kernel32.SetLastError(0)
         thread_h = pymem.ressources.kernel32.CreateRemoteThread(
             self.process_handle,
             None,
@@ -166,8 +167,11 @@ class Pymem(object):
             address,
             params,
             0,
-            None
+            ctypes.byref(thread_id)
         )
+        last_error = ctypes.windll.kernel32.GetLastError()
+        if last_error:
+            pymem.logger.warning('Got an error in start thread, code: %s' % last_error)
         pymem.ressources.kernel32.WaitForSingleObject(thread_h, -1)
         pymem.logger.debug('New thread_id: 0x%08x' % thread_h)
         return thread_h

--- a/pymem/__init__.py
+++ b/pymem/__init__.py
@@ -132,11 +132,13 @@ class Pymem(object):
         shellcode = shellcode.encode('ascii')
         shellcode_addr = pymem.ressources.kernel32.VirtualAllocEx(
             self.process_handle,
-            0,
+            None,
             len(shellcode),
             pymem.ressources.structure.MEMORY_STATE.MEM_COMMIT.value | pymem.ressources.structure.MEMORY_STATE.MEM_RESERVE.value,
-            pymem.ressources.structure.MEMORY_PROTECTION.PAGE_READWRITE.value
+            pymem.ressources.structure.MEMORY_PROTECTION.PAGE_EXECUTE_READWRITE.value
         )
+        if not shellcode_addr or ctypes.get_last_error():
+            raise RuntimeError('Could not allocate memory for shellcode')
         pymem.logger.debug('shellcode_addr loc: 0x%08x' % shellcode_addr)
         written = ctypes.c_ulonglong(0) if '64bit' in platform.architecture() else ctypes.c_ulong(0)
         pymem.ressources.kernel32.WriteProcessMemory(self.process_handle, shellcode_addr, shellcode, len(shellcode), ctypes.byref(written))
@@ -158,16 +160,17 @@ class Pymem(object):
         int
             The new thread identifier
         """
-        thread_id = ctypes.c_ulong(0)
-        ctypes.windll.kernel32.SetLastError(0)
+
+        params = params or 0
+        NULL_SECURITY_ATTRIBUTES = ctypes.cast(0, pymem.ressources.structure.LPSECURITY_ATTRIBUTES)
         thread_h = pymem.ressources.kernel32.CreateRemoteThread(
             self.process_handle,
-            None,
+            NULL_SECURITY_ATTRIBUTES,
             0,
             address,
             params,
             0,
-            ctypes.byref(thread_id)
+            ctypes.byref(ctypes.c_ulong(0))
         )
         last_error = ctypes.windll.kernel32.GetLastError()
         if last_error:

--- a/pymem/process.py
+++ b/pymem/process.py
@@ -1,5 +1,6 @@
 import ctypes
 import logging
+import os
 
 import pymem.ressources.kernel32
 import pymem.ressources.psapi
@@ -38,13 +39,13 @@ def inject_dll(handle, filepath):
         handle, None, 0, load_library_a_address, filepath_address, 0, None
     )
     pymem.ressources.kernel32.WaitForSingleObject(thread_h, -1)
-
-    exitcode = ctypes.c_ulong(0)
-    pymem.ressources.kernel32.GetExitCodeThread(thread_h, ctypes.byref(exitcode))
     pymem.ressources.kernel32.VirtualFreeEx(
         handle, filepath_address, len(filepath), pymem.ressources.structure.MEMORY_STATE.MEM_RELEASE.value
     )
-    return exitcode.value
+    dll_name = os.path.basename(filepath)
+    dll_name = dll_name.decode('ascii')
+    module_address = pymem.ressources.kernel32.GetModuleHandleW(dll_name)
+    return module_address
 
 
 def set_debug_privilege(hToken, lpszPrivilege, bEnablePrivilege):

--- a/pymem/ressources/kernel32.py
+++ b/pymem/ressources/kernel32.py
@@ -223,7 +223,7 @@ CreateRemoteThread.restype = ctypes.c_void_p
 CreateRemoteThread.argtypes = (
     ctypes.c_void_p,
     pymem.ressources.structure.LPSECURITY_ATTRIBUTES,
-    ctypes.c_ulong,
+    ctypes.c_size_t,
     ctypes.c_void_p,
     ctypes.c_void_p,
     ctypes.c_ulong,

--- a/pymem/ressources/kernel32.py
+++ b/pymem/ressources/kernel32.py
@@ -76,7 +76,7 @@ DebugActiveProcess.restype = ctypes.c_long
 #: The function initializes the memory it allocates to zero, unless MEM_RESET is used.
 #:
 #: https://msdn.microsoft.com/en-us/library/windows/desktop/aa366890%28v=vs.85%29.aspx
-VirtualAllocEx  = dll.VirtualAllocEx
+VirtualAllocEx = dll.VirtualAllocEx
 VirtualAllocEx.restype = ctypes.c_void_p
 VirtualAllocEx.argtypes = (
     ctypes.c_void_p,
@@ -215,7 +215,6 @@ GetModuleHandleW.restype = ctypes.c_void_p
 GetModuleHandleW.argtypes = [ctypes.c_wchar_p]
 
 GetProcAddress = dll.GetProcAddress
-#GetProcAddress.restype = ctypes.c_void_p
 GetProcAddress.restype = ctypes.c_void_p
 GetProcAddress.argtypes = (ctypes.c_void_p, ctypes.c_char_p)
 


### PR DESCRIPTION
Why?
====

There is an ongoing issue with injecting python dll into process.
In fact the issue was with inject_dll that can t hold a 64 bit address as a return value of CreateRemoteThread

Changes
======

- Use GetModuleHandleW to retrieve the address of injected dll
- Some stashed documentation

Testing
=====

I personally used this snippet to test the code (it will create a text file within the folder where you run it)

```python
from pymem import Pymem
import os
import subprocess
import ctypes

notepad = subprocess.Popen(['notepad.exe'])

print(notepad.pid)
if not notepad:
    raise RuntimeError('notepad not launched')
pm = Pymem('notepad.exe')

pm.inject_python_interpreter()
filepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'pymem_injection.txt')
filepath = filepath.replace("\\", "\\\\")
shellcode = """
f = open("{}", "w+")
f.write("pymem_injection")
f.close()
""".format(filepath)

print(filepath)
ctypes.windll.kernel32.SetLastError(0)
pm.inject_python_shellcode(shellcode)

notepad.kill()
```