### PR TITLE
fix in __init__.py

### DIFF
--- a/pymem/__init__.py
+++ b/pymem/__init__.py
@@ -5,6 +5,7 @@ import logging
 import platform
 import struct
 import sys
+from win32process import EnumProcessModules, GetModuleFileNameEx
 
 import pymem.exception
 import pymem.memory
@@ -14,7 +15,6 @@ import pymem.ressources.structure
 import pymem.thread
 import pymem.pattern
 
-
 logger = logging.getLogger('pymem')
 logger.setLevel(logging.DEBUG)
 ch = logging.StreamHandler()
@@ -22,6 +22,14 @@ ch.setLevel(logging.DEBUG)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 ch.setFormatter(formatter)
 logger.addHandler(ch)
+
+
+def get_python_dll(version):
+    for process in EnumProcessModules(-1):
+        name = GetModuleFileNameEx(-1, process)
+        if version in name:
+            return name
+    return None
 
 
 class Pymem(object):
@@ -63,18 +71,19 @@ class Pymem(object):
         modules = pymem.process.enum_process_module(self.process_handle)
         return modules
 
-    def inject_python_interpreter(self):
+    def inject_python_interpreter(self, initsigs=1):
         """Inject python interpreter into target process and call Py_InitializeEx.
         """
+
         def find_existing_interpreter(_python_version):
             _local_handle = pymem.ressources.kernel32.GetModuleHandleW(_python_version)
             module = pymem.process.module_from_name(self.process_handle, _python_version)
-            
+
             self.py_run_simple_string = (
-                module.lpBaseOfDll + (
+                    module.lpBaseOfDll + (
                     pymem.ressources.kernel32.GetProcAddress(_local_handle, b'PyRun_SimpleString')
                     - _local_handle
-                )
+            )
             )
             self._python_injected = True
             pymem.logger.debug('PyRun_SimpleString loc: 0x%08x' % self.py_run_simple_string)
@@ -85,7 +94,7 @@ class Pymem(object):
 
         # find the python library
         python_version = "python{0}{1}.dll".format(sys.version_info.major, sys.version_info.minor)
-        python_lib = ctypes.util.find_library(python_version)
+        python_lib = get_python_dll(python_version)
         if not python_lib:
             raise pymem.exception.PymemError('Could not find python library')
 
@@ -100,23 +109,25 @@ class Pymem(object):
 
         local_handle = pymem.ressources.kernel32.GetModuleHandleW(python_version)
         py_initialize_ex = (
-            python_lib_h + (
+                python_lib_h + (
                 pymem.ressources.kernel32.GetProcAddress(local_handle, b'Py_InitializeEx')
                 - local_handle
-            )
+        )
         )
         self.py_run_simple_string = (
-            python_lib_h + (
+                python_lib_h + (
                 pymem.ressources.kernel32.GetProcAddress(local_handle, b'PyRun_SimpleString')
                 - local_handle
-            )
+        )
         )
         if not py_initialize_ex:
             raise pymem.exception.PymemError('Empty py_initialize_ex')
         if not self.py_run_simple_string:
             raise pymem.exception.PymemError('Empty py_run_simple_string')
 
-        self.start_thread(py_initialize_ex)
+        param_addr = self.allocate(4)
+        self.write_int(param_addr, initsigs)
+        self.start_thread(py_initialize_ex, param_addr)
         self._python_injected = True
 
         pymem.logger.debug('Py_InitializeEx loc: 0x%08x' % py_initialize_ex)
@@ -145,7 +156,7 @@ class Pymem(object):
         pymem.ressources.kernel32.WriteProcessMemory(self.process_handle, shellcode_addr, shellcode, len(shellcode), ctypes.byref(written))
         # check written
         self.start_thread(self.py_run_simple_string, shellcode_addr)
-   
+
     def start_thread(self, address, params=None):
         """Create a new thread within the current debugged process.
 

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -2,3 +2,4 @@ recommonmark
 sphinx
 sphinx_rtd_theme
 sphinxcontrib-napoleon
+pywin32

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 codecov
 pytest
 pytest-cov
+pywin32


### PR DESCRIPTION
fix the way to get python dll path, prevent problems cause when using non system default python environment
add the Py_InitializeEx parameters #https://docs.python.org/3/c-api/init.html#c.Py_InitializeEx