### PR TITLE
Fix an issue with VirtualQueryEx and MEMORY_BASIC_INFORMATION

### DIFF
--- a/pymem/memory.py
+++ b/pymem/memory.py
@@ -1118,8 +1118,13 @@ def virtual_query(handle, address):
     MEMORY_BASIC_INFORMATION
         A memory basic information object
     """
-    mbi = pymem.ressources.structure.MEMORY_BASIC_INFORMATION()
-    mbi_pointer = ctypes.byref(mbi)
-    size = ctypes.sizeof(mbi)
-    pymem.ressources.kernel32.VirtualQueryEx(handle, address, mbi_pointer, size)
+    current_bitness = 8 * struct.calcsize("P")
+
+    if current_bitness == 32:
+        mbi = pymem.ressources.structure.MEMORY_BASIC_INFORMATION32()
+    else:
+        mbi = pymem.ressources.structure.MEMORY_BASIC_INFORMATION64()
+
+    mbi_pointer = ctypes.cast(ctypes.byref(mbi), pymem.ressources.structure.MEMORY_BASIC_INFORMATION)
+    pymem.ressources.kernel32.VirtualQueryEx(handle, address, mbi_pointer, ctypes.sizeof(mbi_pointer))
     return mbi

--- a/pymem/memory.py
+++ b/pymem/memory.py
@@ -1125,6 +1125,6 @@ def virtual_query(handle, address):
     else:
         mbi = pymem.ressources.structure.MEMORY_BASIC_INFORMATION64()
 
-    mbi_pointer = ctypes.cast(ctypes.byref(mbi), pymem.ressources.structure.MEMORY_BASIC_INFORMATION)
+    mbi_pointer = ctypes.cast(ctypes.byref(mbi), ctypes.POINTER(pymem.ressources.structure.MEMORY_BASIC_INFORMATION))
     pymem.ressources.kernel32.VirtualQueryEx(handle, address, mbi_pointer, ctypes.sizeof(mbi_pointer))
     return mbi

--- a/pymem/memory.py
+++ b/pymem/memory.py
@@ -1118,13 +1118,11 @@ def virtual_query(handle, address):
     MEMORY_BASIC_INFORMATION
         A memory basic information object
     """
-    current_bitness = 8 * struct.calcsize("P")
-
-    if current_bitness == 32:
-        mbi = pymem.ressources.structure.MEMORY_BASIC_INFORMATION32()
-    else:
-        mbi = pymem.ressources.structure.MEMORY_BASIC_INFORMATION64()
-
-    mbi_pointer = ctypes.cast(ctypes.byref(mbi), ctypes.POINTER(pymem.ressources.structure.MEMORY_BASIC_INFORMATION))
-    pymem.ressources.kernel32.VirtualQueryEx(handle, address, mbi_pointer, ctypes.sizeof(mbi_pointer))
+    mbi = pymem.ressources.structure.MEMORY_BASIC_INFORMATION()
+    ctypes.windll.kernel32.SetLastError(0)
+    pymem.ressources.kernel32.VirtualQueryEx(handle, address, ctypes.byref(mbi), ctypes.sizeof(mbi))
+    error_code = ctypes.windll.kernel32.GetLastError()
+    if error_code:
+        ctypes.windll.kernel32.SetLastError(0)
+        raise pymem.exception.WinAPIError(error_code)
     return mbi

--- a/pymem/pattern.py
+++ b/pymem/pattern.py
@@ -50,6 +50,7 @@ def scan_pattern_page(handle, address, pattern):
 
     return next_region, found
 
+
 def pattern_scan_module(handle, module, pattern):
     """Given a handle over an opened process and a module will scan memory after
     a byte pattern and return its corresponding memory address.

--- a/pymem/ressources/kernel32.py
+++ b/pymem/ressources/kernel32.py
@@ -193,7 +193,7 @@ VirtualQueryEx = dll.VirtualQueryEx
 VirtualQueryEx.argtypes = [
     ctypes.c_void_p,
     ctypes.c_void_p,
-    ctypes.POINTER(pymem.ressources.structure.MEMORY_BASIC_INFORMATION),
+    ctypes.c_void_p,
     ctypes.c_size_t
 ]
 VirtualQueryEx.restype = ctypes.c_ulong

--- a/pymem/ressources/structure.py
+++ b/pymem/ressources/structure.py
@@ -437,23 +437,6 @@ class SYSTEM_INFO(ctypes.Structure):
     ]
 
 
-class MEMORY_BASIC_INFORMATION(ctypes.Structure):
-    """Contains information about a range of pages in the virtual address space of a process.
-    The VirtualQuery and VirtualQueryEx functions use this structure.
-
-    https://msdn.microsoft.com/en-us/library/windows/desktop/aa366775(v=vs.85).aspx
-    """
-    _fields_ = [
-        ("BaseAddress", ctypes.c_ulong),
-        ("AllocationBase", ctypes.c_ulong),
-        ("AllocationProtect", ctypes.c_ulong),
-        ("RegionSize", ctypes.c_ulong),
-        ("State", ctypes.c_ulong),
-        ("Protect", ctypes.c_ulong),
-        ("Type", ctypes.c_ulong)
-    ]
-
-
 class MEMORY_BASIC_INFORMATION32(ctypes.Structure):
     """Contains information about a range of pages in the virtual address space of a process.
     The VirtualQuery and VirtualQueryEx functions use this structure.
@@ -520,6 +503,13 @@ class MEMORY_BASIC_INFORMATION64(ctypes.Structure):
         enum_type = [e for e in MEMORY_PROTECTION if e.value == self.Protect]
         enum_type = enum_type[0] if enum_type else None
         return enum_type
+
+
+PTR_SIZE = ctypes.sizeof(ctypes.c_void_p)
+if PTR_SIZE == 8:       # 64-bit python
+    MEMORY_BASIC_INFORMATION = MEMORY_BASIC_INFORMATION64
+elif PTR_SIZE == 4:     # 32-bit python
+    MEMORY_BASIC_INFORMATION = MEMORY_BASIC_INFORMATION32
 
 
 class EnumProcessModuleEX(object):

--- a/pymem/ressources/structure.py
+++ b/pymem/ressources/structure.py
@@ -444,13 +444,63 @@ class MEMORY_BASIC_INFORMATION(ctypes.Structure):
     https://msdn.microsoft.com/en-us/library/windows/desktop/aa366775(v=vs.85).aspx
     """
     _fields_ = [
-        ("BaseAddress", ctypes.c_ulonglong),
-        ("AllocationBase", ctypes.c_ulonglong),
+        ("BaseAddress", ctypes.c_ulong),
+        ("AllocationBase", ctypes.c_ulong),
         ("AllocationProtect", ctypes.c_ulong),
-        ("RegionSize", ctypes.c_ulonglong),
+        ("RegionSize", ctypes.c_ulong),
         ("State", ctypes.c_ulong),
         ("Protect", ctypes.c_ulong),
         ("Type", ctypes.c_ulong)
+    ]
+
+
+class MEMORY_BASIC_INFORMATION32(ctypes.Structure):
+    """Contains information about a range of pages in the virtual address space of a process.
+    The VirtualQuery and VirtualQueryEx functions use this structure.
+
+    https://msdn.microsoft.com/en-us/library/windows/desktop/aa366775(v=vs.85).aspx
+    """
+    _fields_ = [
+        ("BaseAddress", ctypes.c_ulong),
+        ("AllocationBase", ctypes.c_ulong),
+        ("AllocationProtect", ctypes.c_ulong),
+        ("RegionSize", ctypes.c_ulong),
+        ("State", ctypes.c_ulong),
+        ("Protect", ctypes.c_ulong),
+        ("Type", ctypes.c_ulong)
+    ]
+
+    @property
+    def type(self):
+        enum_type = [e for e in MEMORY_TYPES if e.value == self.Type] or None
+        enum_type = enum_type[0] if enum_type else None
+        return enum_type
+
+    @property
+    def state(self):
+        enum_type = [e for e in MEMORY_STATE if e.value == self.State] or None
+        enum_type = enum_type[0] if enum_type else None
+        return enum_type
+
+    @property
+    def protect(self):
+        enum_type = [e for e in MEMORY_PROTECTION if e.value == self.Protect]
+        enum_type = enum_type[0] if enum_type else None
+        return enum_type
+
+
+class MEMORY_BASIC_INFORMATION64(ctypes.Structure):
+
+    _fields_ = [
+        ("BaseAddress", ctypes.c_ulonglong),
+        ("AllocationBase", ctypes.c_ulonglong),
+        ("AllocationProtect", ctypes.c_ulong),
+        ("__alignment1", ctypes.c_ulong),
+        ("RegionSize", ctypes.c_ulonglong),
+        ("State", ctypes.c_ulong),
+        ("Protect", ctypes.c_ulong),
+        ("Type", ctypes.c_ulong),
+        ("__alignment2", ctypes.c_ulong),
     ]
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(ROOT + '/PYPI-README.md', encoding="utf-8") as fp:
 
 setuptools.setup(
     name='Pymem',
-    version='1.8.1',
+    version='1.8.2',
     long_description=long_description,
     long_description_content_type="text/markdown",
     description='pymem: python memory access made easy',


### PR DESCRIPTION
- Fix an issue with VirtualQueryEx not having the correct MBI structure
- Fix an issue with VirtualQueryEx overflow
- Release pymem 1.8.2

This should fix issue #45