### PR TITLE
use DOTALL for pattern searching

### DIFF
--- a/pymem/pattern.py
+++ b/pymem/pattern.py
@@ -43,7 +43,7 @@ def scan_pattern_page(handle, address, pattern):
 
     found = None
 
-    match = re.search(pattern, page_bytes)
+    match = re.search(pattern, page_bytes, re.DOTALL)
 
     if match:
         found = address + match.span()[0]


### PR DESCRIPTION
This pull request adds the re.DOTALL flag to the pattern search so line break bytes like b"\x0A" (new line) are also matched by .