### PR TITLE
Fixed the problem which not search the pattern with re.search and re.…

### DIFF
--- a/pymem/pattern.py
+++ b/pymem/pattern.py
@@ -51,13 +51,13 @@ def scan_pattern_page(handle, address, pattern, *, return_multiple=False):
         match = re.search(pattern.hex(), page_bytes.hex(), re.DOTALL)
 
         if match:
-            found = address + match.span()[0]
+            found = address + int(match.span()[0]/2.0)
 
     else:
         found = []
 
         for match in re.finditer(pattern.hex(), page_bytes.hex(), re.DOTALL):
-            found_address = address + match.span()[0]
+            found_address = address + int(match.span()[0]/2.0)
             found.append(found_address)
 
     return next_region, found

--- a/pymem/pattern.py
+++ b/pymem/pattern.py
@@ -48,7 +48,7 @@ def scan_pattern_page(handle, address, pattern, *, return_multiple=False):
 
     if not return_multiple:
         found = None
-        match = re.search(pattern, page_bytes, re.DOTALL)
+        match = re.search(pattern.hex(), page_bytes.hex(), re.DOTALL)
 
         if match:
             found = address + match.span()[0]
@@ -56,7 +56,7 @@ def scan_pattern_page(handle, address, pattern, *, return_multiple=False):
     else:
         found = []
 
-        for match in re.finditer(pattern, page_bytes, re.DOTALL):
+        for match in re.finditer(pattern.hex(), page_bytes.hex(), re.DOTALL):
             found_address = address + match.span()[0]
             found.append(found_address)
 


### PR DESCRIPTION
It fixes #76.

The problem is that the module `re` for the functions `search` and `finditer` is not matching with byte arrays (b'\x54\x98').

The solution that I purpose, and it is working in my computer. Convert the byte strings to hex string in the `re` functions.

My thoughts are that maybe it was working before because in PyCharm it marks as `AnyString` (`def search(pattern: Pattern[AnyStr],`) but in the official documentation https://docs.python.org/3.10/library/re.html#re.search, it is showing as a `string` but not specify the byte string.

Or maybe it is something that the official web page says:

> Both patterns and [str](https://docs.python.org/3.10/library/stdtypes.html#str)ings to be searched can be Unicode strings (str) as well as 8-bit strings ([bytes](https://docs.python.org/3.10/library/stdtypes.html#bytes)). However, Unicode strings and 8-bit strings cannot be mixed: that is, you cannot match a Unicode string with a byte pattern or vice-versa; similarly, when asking for a substitution, the replacement string must be of the same type as both the pattern and the search string.