### PR TITLE
Add and use SetLastError types

### DIFF
--- a/pymem/memory.py
+++ b/pymem/memory.py
@@ -33,7 +33,7 @@ def allocate_memory(handle, size, allocation_type=None, protection_type=None):
         allocation_type = pymem.ressources.structure.MEMORY_STATE.MEM_COMMIT.value
     if not protection_type:
         protection_type = pymem.ressources.structure.MEMORY_PROTECTION.PAGE_EXECUTE_READWRITE.value
-    ctypes.windll.kernel32.SetLastError(0)
+    pymem.ressources.kernel32.SetLastError(0)
     address = pymem.ressources.kernel32.VirtualAllocEx(handle, None, size, allocation_type, protection_type)
     return address
 
@@ -61,7 +61,7 @@ def free_memory(handle, address, free_type=None):
     """
     if not free_type:
         free_type = pymem.ressources.structure.MEMORY_STATE.MEM_RELEASE
-    ctypes.windll.kernel32.SetLastError(0)
+    pymem.ressources.kernel32.SetLastError(0)
     ret = pymem.ressources.kernel32.VirtualFreeEx(handle, address, 0, free_type)
     return ret
 
@@ -98,7 +98,7 @@ def read_bytes(handle, address, byte):
         raise TypeError('Address must be int: {}'.format(address))
     buff = ctypes.create_string_buffer(byte)
     bytes_read = ctypes.c_size_t()
-    ctypes.windll.kernel32.SetLastError(0)
+    pymem.ressources.kernel32.SetLastError(0)
     pymem.ressources.kernel32.ReadProcessMemory(
         handle,
         ctypes.c_void_p(address),
@@ -108,7 +108,7 @@ def read_bytes(handle, address, byte):
     )
     error_code = ctypes.windll.kernel32.GetLastError()
     if error_code:
-        ctypes.windll.kernel32.SetLastError(0)
+        pymem.ressources.kernel32.SetLastError(0)
         raise pymem.exception.WinAPIError(error_code)
     raw = buff.raw
     return raw
@@ -618,14 +618,14 @@ def write_bytes(handle, address, data, length):
     bool
         A boolean indicating a successful write.
     """
-    ctypes.windll.kernel32.SetLastError(0)
+    pymem.ressources.kernel32.SetLastError(0)
     if not isinstance(address, int):
         raise TypeError('Address must be int: {}'.format(address))
     dst = ctypes.cast(address, ctypes.c_char_p)
     res = ctypes.windll.kernel32.WriteProcessMemory(handle, dst, data, length, 0x0)
     error_code = ctypes.windll.kernel32.GetLastError()
     if error_code:
-        ctypes.windll.kernel32.SetLastError(0)
+        pymem.ressources.kernel32.SetLastError(0)
         raise pymem.exception.WinAPIError(error_code)
     return res
 
@@ -1129,10 +1129,10 @@ def virtual_query(handle, address):
         A memory basic information object
     """
     mbi = pymem.ressources.structure.MEMORY_BASIC_INFORMATION()
-    ctypes.windll.kernel32.SetLastError(0)
+    pymem.ressources.kernel32.SetLastError(0)
     pymem.ressources.kernel32.VirtualQueryEx(handle, address, ctypes.byref(mbi), ctypes.sizeof(mbi))
     error_code = ctypes.windll.kernel32.GetLastError()
     if error_code:
-        ctypes.windll.kernel32.SetLastError(0)
+        pymem.ressources.kernel32.SetLastError(0)
         raise pymem.exception.WinAPIError(error_code)
     return mbi

--- a/pymem/ressources/kernel32.py
+++ b/pymem/ressources/kernel32.py
@@ -9,6 +9,7 @@ except AttributeError:
         def __getattr__(self, item):
             return self
 
+
     dll = MockObject()
 
 #: Opens an existing local process object.
@@ -38,6 +39,12 @@ CloseHandle.argtypes = [
 #: https://msdn.microsoft.com/en-us/library/windows/desktop/ms679360%28v=vs.85%29.aspx
 GetLastError = dll.GetLastError
 GetLastError.restype = ctypes.c_ulong
+
+#: Sets the last-error code for the calling thread.
+#:
+#: https://docs.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-setlasterror
+SetLastError = dll.SetLastError
+SetLastError.argtypes = [ctypes.c_ulong]
 
 #: Retrieves a pseudo handle for the current process.
 #:


### PR DESCRIPTION
Came across this issue when trying to use `Pymem` with `pyglet` (https://pyglet.org/). 
It seems that the Kernel32.SetLastError types are incorrect for the current pyglet version 1.5. https://github.com/pyglet/pyglet/blob/6de9cc853c0ced894971f5bbf2b7f61174f8c632/pyglet/libs/win32/__init__.py#L159-L160

However the types are now fixed in this PR: https://github.com/pyglet/pyglet/pull/525 but are yet to be released as they are waiting for a 2.0 release.

I'm aware this is not a Pymem issue, but declaring and using the types within Pymem avoid this issue from occurring, and considering I can't really think of a reason why you wouldn't want to add the types and there's a more likely chance Pymem will release a minor version before pyglet 2.0 lands, I'm hoping I can sneak this through the door 🙏🏽 (I have unblocked myself by building a patched pymem locally with these changes)

I searched the Github Issues and Discord,[ looks like someone had experienced this before](https://discord.com/channels/342944948770963476/342944948770963476/911667665561595974) and I assume gave up:
![image](https://user-images.githubusercontent.com/28290599/171411640-080cddf5-3230-40c5-a181-0e1f372049d1.png)
