### PR TITLE
allow initing Pymem objects with process id

### DIFF
--- a/pymem/__init__.py
+++ b/pymem/__init__.py
@@ -28,8 +28,8 @@ class Pymem(object):
 
     Parameters
     ----------
-    process_name: str
-        The name of the process to be opened
+    process_name: str | int
+        The name or process id of the process to be opened
     """
 
     def __init__(self, process_name=None):
@@ -40,8 +40,16 @@ class Pymem(object):
         self.py_run_simple_string = None
         self._python_injected = None
 
-        if process_name:
-            self.open_process_from_name(process_name)
+        if process_name is not None:
+            if isinstance(process_name, str):
+                self.open_process_from_name(process_name)
+            elif isinstance(process_name, int):
+                self.open_process_from_id(process_name)
+            else:
+                raise TypeError(
+                    f"process_name must be of type int or string not {type(process_name).__name__}"
+                )
+
         self.check_wow64()
 
     def check_wow64(self):

--- a/pymem/__init__.py
+++ b/pymem/__init__.py
@@ -40,15 +40,14 @@ class Pymem(object):
         self.py_run_simple_string = None
         self._python_injected = None
 
-        if process_name is not None:
-            if isinstance(process_name, str):
-                self.open_process_from_name(process_name)
-            elif isinstance(process_name, int):
-                self.open_process_from_id(process_name)
-            else:
-                raise TypeError(
-                    f"process_name must be of type int or string not {type(process_name).__name__}"
-                )
+        if isinstance(process_name, str):
+            self.open_process_from_name(process_name)
+        elif isinstance(process_name, int):
+            self.open_process_from_id(process_name)
+        else:
+            raise TypeError(
+                f"process_name must be of type int or string not {type(process_name).__name__}"
+            )
 
         self.check_wow64()
 

--- a/pymem/__init__.py
+++ b/pymem/__init__.py
@@ -40,14 +40,15 @@ class Pymem(object):
         self.py_run_simple_string = None
         self._python_injected = None
 
-        if isinstance(process_name, str):
-            self.open_process_from_name(process_name)
-        elif isinstance(process_name, int):
-            self.open_process_from_id(process_name)
-        else:
-            raise TypeError(
-                f"process_name must be of type int or string not {type(process_name).__name__}"
-            )
+        if process_name is not None:
+            if isinstance(process_name, str):
+                self.open_process_from_name(process_name)
+            elif isinstance(process_name, int):
+                self.open_process_from_id(process_name)
+            else:
+                raise TypeError(
+                    f"process_name must be of type int or string not {type(process_name).__name__}"
+                )
 
         self.check_wow64()
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(ROOT + '/PYPI-README.md', encoding="utf-8") as fp:
 
 setuptools.setup(
     name='Pymem',
-    version='1.9.1',
+    version='1.10.0',
     long_description=long_description,
     long_description_content_type="text/markdown",
     description='pymem: python memory access made easy',

--- a/tests/test_pymem_object.py
+++ b/tests/test_pymem_object.py
@@ -1,0 +1,21 @@
+import os
+
+import pytest
+
+import pymem
+
+
+def test_init_process_by_name():
+    process = pymem.Pymem("python.exe")
+    assert process.base_address is not None
+
+
+def test_init_process_by_id():
+    process = pymem.Pymem(os.getpid())
+    assert process.base_address is not None
+    assert process.process_id == os.getpid()
+
+
+def test_error_init_non_str_int():
+    with pytest.raises(TypeError):
+        pymem.Pymem(1.0)

--- a/tests/test_pymem_object.py
+++ b/tests/test_pymem_object.py
@@ -19,3 +19,8 @@ def test_init_process_by_id():
 def test_error_init_non_str_int():
     with pytest.raises(TypeError):
         pymem.Pymem(1.0)
+
+
+def test_init_none():
+    process = pymem.Pymem()
+    assert process.process_id is None


### PR DESCRIPTION
This pull request allows you to pass a process id to Pymem as in:
```python
process = pymem.Pymem(123)
```
this is a lot more concise than the previous method of doing:
```python
process = pymem.Pymem()
process.open_process_from_id(123)
process.check_wow64()
```

I kept the argument name as `process_name` in case someone was using it as a keyword arg like in:
```python
pymem.Pymem(process_name="process.exe")
```