### PR TITLE
Improve read and write speeds by removing buffer copys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ __pycache__/
 *.idea
 .pytest_cache
 
+# vscode
+.vscode
+
 # Distribution / packaging
 .Python
 env/

--- a/pymem/__init__.py
+++ b/pymem/__init__.py
@@ -471,6 +471,41 @@ class Pymem(object):
             raise pymem.exception.MemoryReadError(address, length, e.error_code)
         return value
 
+    def read_ctype(self, address, ctype, *, get_py_value=True, raw_bytes=False):
+        """
+        Read a ctype basic type or structure from <address>
+
+        Parameters
+        ----------
+        address: int
+            An address of the region of memory to be read.
+        ctype:
+            A simple ctypes type or structure
+        get_py_value: bool
+            If the corrosponding python type should be used instead of returning the ctype
+            This is automatically set to False for ctypes.Structure or ctypes.Array instances
+        raw_bytes: bool
+            If we should return the raw ctype bytes
+
+        Raises
+        ------
+        WinAPIError
+            If ReadProcessMemory failed
+
+        Returns
+        -------
+        Any
+            Return will be either the ctype with the read value if get_py_value is false or 
+            the corropsonding python type
+        """
+        if not self.process_handle:
+            raise pymem.exception.ProcessError('You must open a process before calling this method')
+        try:
+            value = pymem.memory.read_ctype(self.process_handle, address, ctype, get_py_value=get_py_value, raw_bytes=raw_bytes)
+        except pymem.exception.WinAPIError as e:
+            raise pymem.exception.MemoryReadError(address, ctypes.sizeof(ctype), e.error_code)
+        return value 
+
     def read_bool(self, address):
         """Reads 1 byte from an area of memory in a specified process.
 
@@ -925,6 +960,34 @@ class Pymem(object):
             pymem.memory.write_bytes(self.process_handle, address, value, length)
         except pymem.exception.WinAPIError as e:
             raise pymem.exception.MemoryWriteError(address, value, e.error_code)
+
+    def write_ctype(self, address, ctype):
+        """
+        Write a ctype basic type or structure to <address>
+
+        Parameters
+        ----------
+        address: int
+            An address of the region of memory to be written.
+        ctype:
+            A simple ctypes type or structure
+
+        Raises
+        ------
+        WinAPIError
+            If WriteProcessMemory failed
+
+        Returns
+        -------
+        bool
+            A boolean indicating a successful write.
+        """
+        if not self.process_handle:
+            raise pymem.exception.ProcessError('You must open a process before calling this method')
+        try:
+            pymem.memory.write_ctype(self.process_handle, address, ctype)
+        except pymem.exception.WinAPIError as e:
+            raise pymem.exception.MemoryWriteError(address, ctype, e.error_code)
 
     def write_bool(self, address, value):
         """Write `value` to the given `address` into the current opened process.

--- a/pymem/memory.py
+++ b/pymem/memory.py
@@ -199,8 +199,7 @@ def read_char(handle, address):
     str
         The raw value read as a string
     """
-    # TODO: test if this returns a str or int
-    return read_ctype(handle, address, ctypes.c_char())
+    return read_ctype(handle, address, ctypes.c_char()).decode()
 
 
 def read_uchar(handle, address):

--- a/pymem/memory.py
+++ b/pymem/memory.py
@@ -94,10 +94,10 @@ def read_bytes(handle, address, byte):
     bytes
         The raw value read as bytes
     """
-    return bytes(read_ctype(handle, address, (byte * ctypes.c_char)()))
+    return read_ctype(handle, address, (byte * ctypes.c_char)(), get_py_value=False).raw
 
 
-def read_ctype(handle, address, ctype, *, get_py_value=True):
+def read_ctype(handle, address, ctype, *, get_py_value=True, raw_bytes=False):
     """
     Read a ctype basic type or structure from <address>
 
@@ -112,6 +112,9 @@ def read_ctype(handle, address, ctype, *, get_py_value=True):
         A simple ctypes type or structure
     get_py_value: bool
         If the corrosponding python type should be used instead of returning the ctype
+        This is automatically set to False for ctypes.Structure or ctypes.Array instances
+    raw_bytes: bool
+        If we should return the raw ctype bytes
 
     Raises
     ------
@@ -124,6 +127,12 @@ def read_ctype(handle, address, ctype, *, get_py_value=True):
         Return will be either the ctype with the read value if get_py_value is false or 
         the corropsonding python type
     """
+    if raw_bytes:
+        return read_bytes(handle, address, ctypes.sizeof(ctype))
+
+    if isinstance(ctype, (ctypes.Structure, ctypes.Array)):
+        get_py_value = False
+
     pymem.ressources.kernel32.SetLastError(0)
 
     result = pymem.ressources.kernel32.ReadProcessMemory(

--- a/pymem/memory.py
+++ b/pymem/memory.py
@@ -114,11 +114,61 @@ def read_bytes(handle, address, byte):
     return raw
 
 
+def read_ctype(handle, address, ctype, *, get_py_value=True):
+    """
+    Read a ctype basic type or structure from <address>
+
+    Parameters
+    ----------
+    handle: int
+        The handle to a process. The function allocates memory within the virtual address space of this process.
+        The handle must have the PROCESS_VM_OPERATION access right.
+    address: int
+        An address of the region of memory to be read.
+    ctype:
+        A simple ctypes type or structure
+    get_py_value: bool
+        If the corrosponding python type should be used instead of returning the ctype
+
+    Raises
+    ------
+    WinAPIError
+        If ReadProcessMemory failed
+
+    Returns
+    -------
+    Any
+        Return will be either the ctype with the read value if get_py_value is false or 
+        the corropsonding python type
+    """
+    ctype_size = ctypes.sizeof(ctype)
+
+    buffer = ctypes.create_string_buffer(ctype_size)
+    pymem.ressources.kernel32.SetLastError(0)
+
+    result = pymem.ressources.kernel32.ReadProcessMemory(
+        handle,
+        ctypes.c_void_p(address),
+        ctypes.byref(buffer),
+        ctype_size,
+        None,
+    )
+
+    if result == 0:
+        error_code = ctypes.windll.kernel32.GetLastError()
+        raise pymem.exception.WinAPIError(error_code)
+
+    ctypes.memmove(ctypes.byref(ctype), ctypes.byref(buffer), ctype_size)
+
+    if get_py_value:
+        return ctype.value
+    
+    return ctype
+
+
 def read_bool(handle, address):
     """Reads 1 byte from an area of memory in a specified process.
     The entire area to be read must be accessible or the operation fails.
-
-    Unpack the value using struct.unpack('?')
 
     https://msdn.microsoft.com/en-us/library/windows/desktop/ms680553%28v=vs.85%29.aspx
 
@@ -140,18 +190,14 @@ def read_bool(handle, address):
     Returns
     -------
     bool
-        The raw value read as a string
+        The raw value read as a bool
     """
-    data = read_bytes(handle, address, struct.calcsize('?'))
-    data = struct.unpack('?', data)[0]
-    return data
+    return read_ctype(handle, address, ctypes.c_bool())
 
 
 def read_char(handle, address):
     """Reads 1 byte from an area of memory in a specified process.
     The entire area to be read must be accessible or the operation fails.
-
-    Unpack the value using struct.unpack('<b')
 
     https://msdn.microsoft.com/en-us/library/windows/desktop/ms680553%28v=vs.85%29.aspx
 
@@ -175,18 +221,14 @@ def read_char(handle, address):
     str
         The raw value read as a string
     """
-    data = read_bytes(handle, address, struct.calcsize('c'))
-    data = struct.unpack('<c', data)[0]
-    data = data.decode()
-    return data
+    # TODO: test if this returns a str or int
+    return read_ctype(handle, address, ctypes.c_char())
 
 
 def read_uchar(handle, address):
     """Reads 1 byte from an area of memory in a specified process.
     The entire area to be read must be accessible or the operation fails.
 
-    Unpack the value using struct.unpack('<B')
-
     https://msdn.microsoft.com/en-us/library/windows/desktop/ms680553%28v=vs.85%29.aspx
 
     Parameters
@@ -209,17 +251,13 @@ def read_uchar(handle, address):
     int
         The raw value read as an int
     """
-    data = read_bytes(handle, address, struct.calcsize('B'))
-    data = struct.unpack('<B', data)[0]
-    return data
+    return read_ctype(handle, address, ctypes.c_ubyte())
 
 
 def read_short(handle, address):
     """Reads 2 byte from an area of memory in a specified process.
     The entire area to be read must be accessible or the operation fails.
 
-    Unpack the value using struct.unpack('<h')
-
     https://msdn.microsoft.com/en-us/library/windows/desktop/ms680553%28v=vs.85%29.aspx
 
     Parameters
@@ -242,17 +280,13 @@ def read_short(handle, address):
     int
         The raw value read as an int
     """
-    data = read_bytes(handle, address, struct.calcsize('h'))
-    data = struct.unpack('<h', data)[0]
-    return data
+    return read_ctype(handle, address, ctypes.c_short())
 
 
 def read_ushort(handle, address):
     """Reads 2 byte from an area of memory in a specified process.
     The entire area to be read must be accessible or the operation fails.
 
-    Unpack the value using struct.unpack('<H')
-
     https://msdn.microsoft.com/en-us/library/windows/desktop/ms680553%28v=vs.85%29.aspx
 
     Parameters
@@ -275,17 +309,13 @@ def read_ushort(handle, address):
     int
         The raw value read as an int
     """
-    data = read_bytes(handle, address, struct.calcsize('H'))
-    data = struct.unpack('<H', data)[0]
-    return data
+    return read_ctype(handle, address, ctypes.c_ushort())
 
 
 def read_int(handle, address):
     """Reads 4 byte from an area of memory in a specified process.
     The entire area to be read must be accessible or the operation fails.
 
-    Unpack the value using struct.unpack('<i')
-
     https://msdn.microsoft.com/en-us/library/windows/desktop/ms680553%28v=vs.85%29.aspx
 
     Parameters
@@ -308,16 +338,12 @@ def read_int(handle, address):
     int
         The raw value read as an int
     """
-    data = read_bytes(handle, address, struct.calcsize('i'))
-    data = struct.unpack('<i', data)[0]
-    return data
+    return read_ctype(handle, address, ctypes.c_int())
 
 
 def read_uint(handle, address, is_64=False):
     """Reads 4 byte from an area of memory in a specified process.
     The entire area to be read must be accessible or the operation fails.
-
-    Unpack the value using struct.unpack('<I')
 
     https://msdn.microsoft.com/en-us/library/windows/desktop/ms680553%28v=vs.85%29.aspx
 
@@ -343,6 +369,7 @@ def read_uint(handle, address, is_64=False):
     int
         The raw value read as an int
     """
+    # TODO: why does this do this bid-endian thing
     raw = read_bytes(handle, address, struct.calcsize('I'))
     if not is_64:
         raw = struct.unpack('<I', raw)[0]
@@ -356,8 +383,6 @@ def read_float(handle, address):
     """Reads 4 byte from an area of memory in a specified process.
     The entire area to be read must be accessible or the operation fails.
 
-    Unpack the value using struct.unpack('<f')
-
     https://msdn.microsoft.com/en-us/library/windows/desktop/ms680553%28v=vs.85%29.aspx
 
     Parameters
@@ -380,17 +405,13 @@ def read_float(handle, address):
     float
         The raw value read as a float
     """
-    data = read_bytes(handle, address, struct.calcsize('f'))
-    data = struct.unpack('<f', data)[0]
-    return data
+    return read_ctype(handle, address, ctypes.c_float())
 
 
 def read_long(handle, address):
     """Reads 4 byte from an area of memory in a specified process.
     The entire area to be read must be accessible or the operation fails.
 
-    Unpack the value using struct.unpack('<l')
-
     https://msdn.microsoft.com/en-us/library/windows/desktop/ms680553%28v=vs.85%29.aspx
 
     Parameters
@@ -413,17 +434,13 @@ def read_long(handle, address):
     int
         The raw value read as an int
     """
-    data = read_bytes(handle, address, struct.calcsize('l'))
-    data = struct.unpack('<l', data)[0]
-    return data
+    return read_ctype(handle, address, ctypes.c_long())
 
 
 def read_ulong(handle, address):
     """Reads 4 byte from an area of memory in a specified process.
     The entire area to be read must be accessible or the operation fails.
 
-    Unpack the value using struct.unpack('<L')
-
     https://msdn.microsoft.com/en-us/library/windows/desktop/ms680553%28v=vs.85%29.aspx
 
     Parameters
@@ -446,17 +463,13 @@ def read_ulong(handle, address):
     int
         The raw value read as an int
     """
-    data = read_bytes(handle, address, struct.calcsize('L'))
-    data = struct.unpack('<L', data)[0]
-    return data
+    return read_ctype(handle, address, ctypes.c_ulong())
 
 
 def read_longlong(handle, address):
     """Reads 8 byte from an area of memory in a specified process.
     The entire area to be read must be accessible or the operation fails.
 
-    Unpack the value using struct.unpack('<q')
-
     https://msdn.microsoft.com/en-us/library/windows/desktop/ms680553%28v=vs.85%29.aspx
 
     Parameters
@@ -479,17 +492,13 @@ def read_longlong(handle, address):
     int
         The raw value read as an int
     """
-    data = read_bytes(handle, address, struct.calcsize('q'))
-    data = struct.unpack('<q', data)[0]
-    return data
+    return read_ctype(handle, address, ctypes.c_longlong())
 
 
 def read_ulonglong(handle, address):
     """Reads 8 byte from an area of memory in a specified process.
     The entire area to be read must be accessible or the operation fails.
 
-    Unpack the value using struct.unpack('<Q')
-
     https://msdn.microsoft.com/en-us/library/windows/desktop/ms680553%28v=vs.85%29.aspx
 
     Parameters
@@ -512,16 +521,12 @@ def read_ulonglong(handle, address):
     int
         The raw value read as an int
     """
-    data = read_bytes(handle, address, struct.calcsize('Q'))
-    data = struct.unpack('<Q', data)[0]
-    return data
+    return read_ctype(handle, address, ctypes.c_ulonglong())
 
 
 def read_double(handle, address):
     """Reads 8 byte from an area of memory in a specified process.
     The entire area to be read must be accessible or the operation fails.
-
-    Unpack the value using struct.unpack('<d')
 
     https://msdn.microsoft.com/en-us/library/windows/desktop/ms680553%28v=vs.85%29.aspx
 
@@ -545,9 +550,7 @@ def read_double(handle, address):
     float
         The raw value read as a float
     """
-    data = read_bytes(handle, address, struct.calcsize('d'))
-    data = struct.unpack('<d', data)[0]
-    return data
+    return read_ctype(handle, address, ctypes.c_double())
 
 
 def read_string(handle, address, byte=50):

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -364,3 +364,28 @@ def test_write_uchar():
     with pytest.raises(pymem.exception.ProcessError):
         pm.write_uchar(0x111111, 114)
 
+
+def test_read_ctype_structure():
+    process = pymem.Pymem("python.exe")
+    address = process.allocate(10)
+
+    import ctypes
+
+    class TestStruct(ctypes.Structure):
+        _fields_ = [
+            ("x", ctypes.c_int),
+            ("y", ctypes.c_int),
+        ]
+
+    pymem.memory.write_ctype(process.process_handle, address, TestStruct(123, 456))
+
+    test = pymem.memory.read_ctype(process.process_handle, address, TestStruct())
+
+    assert test.x == 123
+    assert test.y == 456
+
+    raw = pymem.memory.read_ctype(process.process_handle, address, TestStruct(), raw_bytes=True)
+
+    # this is 123 456 packed as bytes
+    assert raw == b"\x7B\x00\x00\x00\xC8\x01\x00\x00"
+


### PR DESCRIPTION
This pull request implements the proposed changes in #101 by adding the new memory.read/write_ctype functions and updating the previous read and write methods to use these new functions

you can see some of the observed speed improvements in the original issue 

as a byproduct the new ctype based functions can also read ctype.Structures 

I added a new test for this functionality and all previous tests seem to pass with the new read/write method