### PR TITLE
Also scan for PAGE_EXECUTE protected memory.

### DIFF
--- a/pymem/pattern.py
+++ b/pymem/pattern.py
@@ -54,6 +54,7 @@ def scan_pattern_page(handle, address, pattern, *, return_multiple=False):
     mbi = pymem.memory.virtual_query(handle, address)
     next_region = mbi.BaseAddress + mbi.RegionSize
     allowed_protections = [
+        pymem.ressources.structure.MEMORY_PROTECTION.PAGE_EXECUTE,
         pymem.ressources.structure.MEMORY_PROTECTION.PAGE_EXECUTE_READ,
         pymem.ressources.structure.MEMORY_PROTECTION.PAGE_EXECUTE_READWRITE,
         pymem.ressources.structure.MEMORY_PROTECTION.PAGE_READWRITE,


### PR DESCRIPTION
Suggestion taken from Discord support channel.

Add `PAGE_EXECUTE` protection to `scan_pattern_page`.