### PR TITLE
fix is_64_bit (closes #113)

### DIFF
--- a/pymem/__init__.py
+++ b/pymem/__init__.py
@@ -62,10 +62,18 @@ class Pymem(object):
 
         self.check_wow64()
 
+    # TODO: 2.0 turn this into a cached property (see is_64_bit)
     def check_wow64(self):
         """Check if a process is running under WoW64.
         """
-        self.is_WoW64 = pymem.process.is_64_bit(self.process_handle)
+        self.is_WoW64 = pymem.process.is_wow64(self.process_handle)
+
+    @functools.cached_property
+    def is_64_bit(self) -> bool:
+        """
+        If the process is 64 bit
+        """
+        return pymem.process.is_64_bit(self.process_handle)
 
     def list_modules(self):
         """List a process loaded modules.
@@ -85,7 +93,7 @@ class Pymem(object):
             base_offset (int): The base address offset
             offsets (list[int]): List of offsets
         """
-        if self.is_WoW64:
+        if self.is_64_bit:
             read_method = self.read_ulonglong
         else:
             read_method = self.read_uint

--- a/pymem/process.py
+++ b/pymem/process.py
@@ -2,6 +2,7 @@ import ctypes
 import locale
 import logging
 import os
+import sys
 
 import pymem.ressources.advapi32
 import pymem.ressources.kernel32
@@ -431,8 +432,7 @@ def enum_process_module(handle):
             yield module_info
 
 
-# TODO: should this be named is_wow64?
-def is_64_bit(handle):
+def is_wow64(handle):
     """Determines whether the specified process is running under WOW64 (emulation).
 
     Parameters
@@ -448,3 +448,20 @@ def is_64_bit(handle):
     Wow64Process = ctypes.c_long()
     pymem.ressources.kernel32.IsWow64Process(handle, ctypes.byref(Wow64Process))
     return bool(Wow64Process.value)
+
+
+def is_64_bit(handle) -> bool:
+    """Determines whether the specified process is 64 bit
+
+    Parameters
+    ----------
+    handle: int
+        Handle of the process to check 64 bit status of
+
+    Returns
+    -------
+    bool
+        If the process is 64 bit
+    """
+    system_64_bit = sys.maxsize > 2**32
+    return system_64_bit and not is_wow64(handle)


### PR DESCRIPTION
this pull request fixes is_64_bit to hopefully return True if the process is 64_bit

I changed the old function to is_wow64 and changed the pointer_resolve method to use the new is_64_bit function which I also exposed as a property of Pymem