### PR TITLE
Fixed issue with inject_dll function failing when injecting DLLs with non-ANSI characters in path

### DIFF
--- a/pymem/__init__.py
+++ b/pymem/__init__.py
@@ -15,7 +15,7 @@ import pymem.ressources.structure
 import pymem.ressources.psapi
 import pymem.thread
 import pymem.pattern
-
+import warnings
 
 # Configure pymem's handler to the lowest level possible so everything is cached and could be later displayed
 logger = logging.getLogger(__name__)
@@ -23,6 +23,10 @@ logger.setLevel(logging.DEBUG)
 logger.addHandler(logging.NullHandler())
 
 
+def disable_deprecated_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+
+    
 class Pymem(object):
     """Initialize the Pymem class.
     If process_name is given, will open the process and retrieve a handle over it.
@@ -135,7 +139,7 @@ class Pymem(object):
         if python_module:
             python_lib_h = find_existing_interpreter(python_version)
         else:
-            python_lib_h = pymem.process.inject_dll(self.process_handle, bytes(python_lib, 'ascii'))
+            python_lib_h = pymem.process.inject_dll_from_path(self.process_handle, bytes(python_lib, 'ascii'))
             if not python_lib_h:
                 raise pymem.exception.PymemError('Inject dll failed')
 


### PR DESCRIPTION
The `inject_dll_from_path` function allows injecting a DLL into an opened process using the Unicode version of LoadLibrary (LoadLibraryW). This function supports paths containing non-ASCII characters and provides better compatibility with the latest version of the library.

The new function replaces the `inject_dll` function, which used the ANSI version of LoadLibrary (LoadLibraryA). The LoadLibraryA function's handling of path names is tied to the system's ANSI code page, making it unreliable for paths with non-English characters due to dependency on the current ANSI code page settings. This can result in failure to load DLLs if the path contains non-English characters.

Changing the system's locale to adjust the ANSI code page for non-English character support is possible but not recommended, as it impacts the entire system and could negatively affect other non-Unicode applications.

The optimal approach is to use LoadLibraryW, which supports UTF-16 encoded strings, ensuring compatibility with all Unicode characters.