### PR TITLE
Rename open function to open_process to avoid conflict with Python's …

### DIFF
--- a/pymem/__init__.py
+++ b/pymem/__init__.py
@@ -296,7 +296,7 @@ class Pymem(object):
         if not process_id or not isinstance(process_id, int):
             raise TypeError('Invalid argument: {}'.format(process_id))
         self.process_id = process_id
-        self.process_handle = pymem.process.open(self.process_id)
+        self.process_handle = pymem.process.open_process(self.process_id)
         if not self.process_handle:
             raise pymem.exception.CouldNotOpenProcess(self.process_id)
         pymem.logger.debug('Process {} is being debugged'.format(

--- a/pymem/process.py
+++ b/pymem/process.py
@@ -27,7 +27,7 @@ def get_python_dll(version):
         The full path of dll
     """
     current_process_id = os.getpid()
-    current_process_handle = pymem.process.open(current_process_id)
+    current_process_handle = pymem.process.open_process(current_process_id)
     for module in pymem.process.enum_process_module(current_process_handle):
         if module.name == version:
             return module.filename
@@ -215,7 +215,7 @@ def base_module(handle):
     return module_info
 
 
-def open(process_id, debug=True, process_access=None):
+def open_process(process_id, debug=True, process_access=None):
     """Open a process given its process_id.
     By default, the process is opened with full access and in debug mode.
 


### PR DESCRIPTION
…built-in open

Renamed the open function in the pymem package to open_process to avoid conflicts with Python's built-in open function. This change prevents errors such as AttributeError: __enter__ when using the with statement for file operations. Updated all relevant references in the code to use the new function name.

**Related issue**: https://github.com/srounet/Pymem/issues/142