### PR TITLE
gh-109: Fix issue with getting module handle from injected dlls

### DIFF
--- a/pymem/process.py
+++ b/pymem/process.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 
+import pymem.process
 import pymem.ressources.advapi32
 import pymem.ressources.kernel32
 import pymem.ressources.psapi
@@ -79,8 +80,9 @@ def inject_dll_from_ansi(handle:int, filepath:bytes):
     )
     dll_name = os.path.basename(filepath)
     dll_name = dll_name.decode('ascii')
-    module_address = pymem.ressources.kernel32.GetModuleHandleW(dll_name)
-    return module_address
+    module_handle = pymem.process.module_from_name(handle, dll_name)
+    if module_handle is not None:
+        return module_handle.lpBaseOfDll
 
 def inject_dll_from_path(handle:int, filepath:str):
     """Inject a dll into opened process. Use `Unicode` version of LoadLibrary (LoadLibraryW)
@@ -116,8 +118,9 @@ def inject_dll_from_path(handle:int, filepath:str):
         handle, filepath_address, len(filepath_bytes), pymem.ressources.structure.MEMORY_STATE.MEM_RELEASE.value
     )
     dll_name = os.path.basename(filepath)
-    module_address = pymem.ressources.kernel32.GetModuleHandleW(dll_name)
-    return module_address
+    module_handle = pymem.process.module_from_name(handle, dll_name)
+    if module_handle is not None:
+        return module_handle.lpBaseOfDll
 
 # To maintain compatibility with the previous version of the library
 inject_dll=inject_dll_from_ansi


### PR DESCRIPTION
closes #109 

Tested this by using the following code:

```py
import os.path as op
import os
import subprocess
import sys
import pymem
import pymem.process

# Python version to inject
PYTHON_VERSION = "39"
PYTHON_VERSION2 = "310"

_ver = sys.version_info
running_python_version = f"{_ver.major}{_ver.minor}"

notepad = subprocess.Popen(['notepad.exe'])
pm = pymem.Pymem('notepad.exe')

# Make sure that the running version is different to the one getting injected.
assert PYTHON_VERSION != running_python_version

# This assumes that python has been installed in the "usual" location (ie. default as per the installer).
python_dll_path = op.join(op.expanduser("~"), f"AppData\\Local\\Programs\\Python\\Python{PYTHON_VERSION}\\python{PYTHON_VERSION}.dll")
python_dll_path2 = op.join(op.expanduser("~"), f"AppData\\Local\\Programs\\Python\\Python{PYTHON_VERSION2}\\python{PYTHON_VERSION2}.dll")

handle = pymem.process.inject_dll_from_path(pm.process_handle, python_dll_path)
assert handle is not None
print(handle)

handle = pymem.process.inject_dll_from_path(pm.process_handle, python_dll_path2)
assert handle is not None
print(handle)

os.kill(pm.process_id, 9)
```

This code was run using a python 3.13 interpreter, however it could be anything other than 3.9 or 3.10 (versions can be changed around to accommodate the running version... They just need to be different from it)