### PR TITLE
Check python interpreter has been injected before allowing shellcode injection

### DIFF
--- a/pymem/__init__.py
+++ b/pymem/__init__.py
@@ -175,6 +175,8 @@ class Pymem(object):
         shellcode: str
             A string with python instructions.
         """
+        if self._python_injected is not True:
+            raise RuntimeError('Python interpreter must be injected before injecting shellcode')
         shellcode = shellcode.encode('ascii')
         shellcode_addr = pymem.ressources.kernel32.VirtualAllocEx(
             self.process_handle,


### PR DESCRIPTION
This might help to clear up some issues as sometimes the logging.debug calls fail because a value is None and it tries to format that as a hex. This should stop it from ever getting that far (at least for this one case)